### PR TITLE
feat: adds KeyDB caching

### DIFF
--- a/.docker/keydb/keydb.conf
+++ b/.docker/keydb/keydb.conf
@@ -16,7 +16,7 @@ databases 8
 ## save 300 100000
 save ""
 maxmemory 2gb
-maxmemory-policy allkeys-lru
+maxmemory-policy volatile-lru
 maxmemory-samples 3
 appendonly no
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,11 +4,15 @@
 root = true
 
 [*]
-indent_size=4
 indent_style = space
+indent_size=4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
+
+[*Taskfile.yml]
+indent_style = space
+indent_size = 2
 
 [{*.js,*.ts,*.json}]
 indent_style = space

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ KEYDB_CACHE_SECRET='changeme'
 # keyDB Cache Default TTL
 KEYDB_CACHE_TTL=3600
 # keyDB Cache Unix Socket
-KEYDB_CACHE_UNIXSOCKET='/var/run/sockets/keydb.sock'
+KEYDB_CACHE_UNIXSOCKET='/var/run/sockets/keydb_socket.sock'
 # MongoDB Database DB
 MONGODB_DATABASE_DB='wow_recruitment'
 # MongoDB Database Host

--- a/.env.test
+++ b/.env.test
@@ -19,7 +19,7 @@ KEYDB_CACHE_SECRET='changeme'
 # keyDB Cache Default TTL
 KEYDB_CACHE_TTL=3600
 # keyDB Cache Unix Socket
-KEYDB_CACHE_UNIXSOCKET='/var/run/sockets/keydb.sock'
+KEYDB_CACHE_UNIXSOCKET='/var/run/sockets/keydb_socket.sock'
 # MongoDB Database DB
 MONGODB_DATABASE_DB='wow_recruitment'
 # MongoDB Database Host

--- a/.tasks/ciTaskfile.yml
+++ b/.tasks/ciTaskfile.yml
@@ -4,6 +4,10 @@ includes:
   docker: ../.docker
 
 tasks:
+  test:
+    cmds:
+      - task: docker:exec
+        vars: {DOCKER_USER: www-data, DOCKER_CONTAINER: 'wrt_app', EXEC_COMMAND: './vendor/bin/simple-phpunit --testdox'}
   phpcs-fix:
     cmds:
       - task: docker:exec

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -1,19 +1,29 @@
 framework:
     cache:
-        # Unique name of your app: used to compute stable namespaces for cache keys.
-        #prefix_seed: your_vendor_name/app_name
+        prefix_seed: aledefreitas/wrt_app
+        app: app.cache.adapter
 
-        # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
-        # Other options include:
+services:
+    App\Foundation\Cache\Contracts\CacheConfigInterface:
+        factory: [ '@App\Foundation\Cache\CacheConfigFactory', 'createConfig' ]
+        arguments:
+            - cache-host: '%env(string:KEYDB_CACHE_HOST)%'
+              cache-port: '%env(string:KEYDB_CACHE_PORT)%'
+              cache-secret: '%env(urlencode:string:KEYDB_CACHE_SECRET)%'
+              cache-unix-socket: '%env(string:KEYDB_CACHE_UNIXSOCKET)%'
+              cache-default-ttl: '%env(int:KEYDB_CACHE_TTL)%'
 
-        # Redis
-        #app: cache.adapter.redis
-        #default_redis_provider: redis://localhost
+    app.cache.adapter.factory:
+        class: 'App\Foundation\Cache\Adapter\CacheAdapterFactory'
 
-        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
-        #app: cache.adapter.apcu
+    app.cache.adapter:
+        class: 'App\Foundation\Cache\Contracts\Adapter\CacheAdapterFactoryInterface'
+        factory: [ '@app.cache.adapter.factory', 'createAdapter' ]
+        arguments:
+            - 'namespace'
+            - '@App\Foundation\Cache\Contracts\CacheConfigInterface'
 
-        # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+when@test:
+    services:
+        app.cache.adapter.factory:
+            class: 'App\Foundation\Testing\Cache\Adapter\CacheAdapterFactory'

--- a/docs/taskfile/README.md
+++ b/docs/taskfile/README.md
@@ -28,6 +28,7 @@ The goal with this documentation is to keep an organized view of all current tas
     - [`ci:phpcs`](#ciphpcs)
     - [`ci:phpstan`](#ciphpstan)
     - [`ci:psalm`](#cipsalm)
+    - [`ci:test`](#citest)
 
 # Tasks
 
@@ -170,4 +171,10 @@ $ task ci:phpstan -- CLI_ARGS=*
 Runs `psalm` inside the container against all application code
 ```sh
 $ task ci:psalm
+```
+
+### `ci:test`
+Runs `phpunit` inside the container with `--testdox` param
+```sh
+$ task ci:test
 ```

--- a/src/Controller/Api/V1/VersionController.php
+++ b/src/Controller/Api/V1/VersionController.php
@@ -2,16 +2,21 @@
 
 namespace App\Controller\Api\V1;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use App\Services\Version\ApiVersionService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Controller for API version.
  */
-#[Route('/api/v1/version', name: 'api_version', methods: ['GET'])]
-final class VersionController extends AbstractController
+#[Route('/api/v1/version', name: 'api_v1_version', methods: ['GET'])]
+final class VersionController
 {
+    public function __construct(
+        private readonly ApiVersionService $apiVersionService
+    ) {
+    }
+
     /**
      * Returns the current version of our API.
      */
@@ -19,7 +24,7 @@ final class VersionController extends AbstractController
     {
         return new JsonResponse(
             [
-                'version' => $this->getParameter('app.version'),
+                'version' => $this->apiVersionService->getCurrentApiVersion(),
             ]
         );
     }

--- a/src/Foundation/Cache/Adapter/CacheAdapterFactory.php
+++ b/src/Foundation/Cache/Adapter/CacheAdapterFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Foundation\Cache\Adapter;
+
+use App\Foundation\Cache\Contracts\Adapter\CacheAdapterFactoryInterface;
+use App\Foundation\Cache\Contracts\CacheConfigInterface;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+final class CacheAdapterFactory implements CacheAdapterFactoryInterface
+{
+    /**
+     * Creates a dynamic instance of cache.
+     */
+    public static function createAdapter(string $namespace, CacheConfigInterface $config): TagAwareAdapterInterface
+    {
+        $redisClient = RedisAdapter::createConnection(
+            static::buildDsnString(
+                host: $config->getParam('cache-host'),
+                secret: $config->getParam('cache-secret'),
+                unixSocket: $config->getParam('cache-unix-socket'),
+                port: $config->getParam('cache-port')
+            )
+        );
+
+        return new RedisTagAwareAdapter(
+            $redisClient,
+            $namespace,
+            $config->getParam('cache-default-ttl'),
+        );
+    }
+
+    /**
+     * Dynamically builds the DSN string to connect to redis.
+     */
+    private static function buildDsnString(
+        string $host,
+        ?string $secret,
+        ?string $unixSocket,
+        int $port = 6379
+    ): ?string {
+        $multipleHosts = explode(',', $host);
+        $secret = $secret ? $secret . '@' : $secret;
+
+        return match (true) {
+            1 < count($multipleHosts) => '',
+            $unixSocket || $host => 'redis://' . $secret . match (true) {
+                $unixSocket => $unixSocket,
+                default => $host . ':' . $port,
+            },
+            default => null
+        };
+    }
+}

--- a/src/Foundation/Cache/CacheConfig.php
+++ b/src/Foundation/Cache/CacheConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Foundation\Cache;
+
+use App\Foundation\Cache\Contracts\CacheConfigInterface;
+
+final class CacheConfig implements CacheConfigInterface
+{
+    private const DEFAULT_PARAMS = [
+        'cache-host' => null,
+        'cache-port' => null,
+        'cache-secret' => null,
+        'cache-unix-socket' => null,
+        'namespace' => null,
+        'cache-default-ttl' => null,
+    ];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function __construct(
+        private array $params = []
+    ) {
+        $this->params = [
+            ...self::DEFAULT_PARAMS,
+            ...$params,
+        ];
+    }
+
+    /**
+     * Returns a parameter for this CacheConfig.
+     */
+    public function getParam(string $key): mixed
+    {
+        return $this->params[$key] ?? null;
+    }
+}

--- a/src/Foundation/Cache/CacheConfigFactory.php
+++ b/src/Foundation/Cache/CacheConfigFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Foundation\Cache;
+
+use App\Foundation\Cache\Contracts\CacheConfigInterface;
+
+final class CacheConfigFactory
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public static function createConfig(array $params): CacheConfigInterface
+    {
+        return new CacheConfig($params);
+    }
+}

--- a/src/Foundation/Cache/Contracts/Adapter/CacheAdapterFactoryInterface.php
+++ b/src/Foundation/Cache/Contracts/Adapter/CacheAdapterFactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Foundation\Cache\Contracts\Adapter;
+
+use App\Foundation\Cache\Contracts\CacheConfigInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+interface CacheAdapterFactoryInterface
+{
+    public static function createAdapter(string $namespace, CacheConfigInterface $config): TagAwareAdapterInterface;
+}

--- a/src/Foundation/Cache/Contracts/CacheConfigInterface.php
+++ b/src/Foundation/Cache/Contracts/CacheConfigInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Foundation\Cache\Contracts;
+
+interface CacheConfigInterface
+{
+    public function getParam(string $key): mixed;
+}

--- a/src/Foundation/Testing/Cache/Adapter/CacheAdapterFactory.php
+++ b/src/Foundation/Testing/Cache/Adapter/CacheAdapterFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Foundation\Testing\Cache\Adapter;
+
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+final class CacheAdapterFactory
+{
+    /**
+     * Creates an instance of cache for testing.
+     */
+    public static function createAdapter(): TagAwareAdapterInterface
+    {
+        return new TagAwareAdapter(
+            new NullAdapter()
+        );
+    }
+}

--- a/src/Services/Version/ApiVersionService.php
+++ b/src/Services/Version/ApiVersionService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\Version;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class ApiVersionService
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly ParameterBagInterface $containerParams
+    ) {
+    }
+
+    public function getCurrentApiVersion(): string
+    {
+        return $this->cache->get('service.api.version', function (ItemInterface $item): string {
+            $item->tag(['api', 'version']);
+
+            return $this->containerParams->get('app.version');
+        });
+    }
+}


### PR DESCRIPTION
# In this PR...
- ### Adds caching with a dynamic cache adapter
It can interpret a `KEYDB_CACHE_HOST` env with multiple hosts separated by commas (`,`) and build the DSN string accordingly

- ### Adds cache override for test environment
When `APP_ENV` is `test`, the application will automatically use [NullAdapter](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Cache/Adapter/NullAdapter.php)

closes #11 